### PR TITLE
README: speed up example ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,5 +66,5 @@ jobs:
       - run: |
           mv $PROJECT_NAME ${{ runner.temp }}/
           cd ${{ runner.temp }}/$PROJECT_NAME
-          cargo build --release
+          cargo check
 ```


### PR DESCRIPTION
Use `cargo check` instead of `cargo build` because we don't need the binary.