### PR TITLE
release(0.18.5) bump used cargo-generate version number

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.73.0-alpine3.18
 
-ENV CARGO_GEN_VERSION="0.18.4"
+ENV CARGO_GEN_VERSION="0.18.5"
 
 # downloads from: https://github.com/cargo-generate/cargo-generate/releases/download/v0.18.4/cargo-generate-v0.18.4-x86_64-unknown-linux-musl.tar.gz
 RUN set -eux; \


### PR DESCRIPTION
depends on 
https://github.com/cargo-generate/cargo-generate/actions/runs/6831121722 
being done and artifacts are attached to the release
https://github.com/cargo-generate/cargo-generate/releases/tag/v0.18.5

