### PR TITLE
Fixed argument parsing in entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,4 +7,4 @@ if [ -z "$USER" ]; then
     export USER="runner"
 fi
 
-/usr/bin/cargo-generate generate --silent $*
+printf '%s\n' "generate --silent $*" | xargs /usr/bin/cargo-generate


### PR DESCRIPTION
I ran into issues with argument parsing when trying to use a subfolder template.

This seems to work in my own [action](https://github.com/JohnPeel/cargo-generate-action).